### PR TITLE
Try all mirrors, not only the primary/fallback sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,30 @@ $ dig +short _http._tcp.pkg.freebsd.org srv
 50 10 80 pkg0.tuk.freebsd.org.
 ```
 
-However, this method does not choose the fastest mirror. This script can help you to find the fastest pkg mirror near you. At the end of the output you'll see a sample configuration to hardcode the fastest pkg mirror leading to much higher pkg performance.
+However, this method will try to choose the nearest mirror, which will not necessarily be the fastest. This script can help you to find the fastest pkg mirror by trying each one in succession. At the end of the output you'll see a sample configuration to hardcode the fastest pkg mirror leading to much higher pkg performance.
 
 
 ```console
 $ ./fastest_pkg.py 
-pkg0.bme.freebsd.org: 16.1 MB/s
+pkg0.tuk.freebsd.org: 2.4 MB/s
+pkg0.twn.freebsd.org: 16.8 MB/s
+pkg0.bbt.freebsd.org: 7.7 MB/s
+pkg0.bme.freebsd.org: 1.6 MB/s
+pkg0.bra.freebsd.org: 68.2 kB/s
 pkg0.isc.freebsd.org: 0.0 B/s
-pkg0.nyi.freebsd.org: 4.7 MB/s
-pkg0.pkt.freebsd.org: 11.9 MB/s
-pkg0.tuk.freebsd.org: 2.2 MB/s
+pkg0.jinx.freebsd.org: 65.6 kB/s
+pkg0.kul.freebsd.org: 7.8 MB/s
+pkg0.kwc.freebsd.org: 8.7 MB/s
+pkg0.pkt.freebsd.org: 1.7 MB/s
+pkg0.nyi.freebsd.org: 1.6 MB/s
 
 Fastest:
-pkg0.bme.freebsd.org: 16.1 MB/s
+pkg0.twn.freebsd.org: 16.8 MB/s
 
 
 Write configuration:
 mkdir -p /usr/local/etc/pkg/repos/
-echo 'FreeBSD: { url: "http://pkg0.bme.freebsd.org/${ABI}/latest" }' \
+echo 'FreeBSD: { url: "http://pkg0.twn.freebsd.org/${ABI}/quarterly" }' \
         > /usr/local/etc/pkg/repos/FreeBSD.conf
 
 ```

--- a/fastest_pkg/fastest_pkg.py
+++ b/fastest_pkg/fastest_pkg.py
@@ -84,9 +84,9 @@ def get_mirrors():
     """returns a list of all mirrors for pkg.freebsd.org"""
     resolver = dns.resolver.Resolver()
     try:
-        pkg_mirrors = resolver.resolve("_http._tcp.pkg.freebsd.org", "SRV")
+        pkg_mirrors = resolver.resolve("_http._tcp.pkg.all.freebsd.org", "SRV")
     except AttributeError:
-        pkg_mirrors = resolver.query("_http._tcp.pkg.freebsd.org", "SRV")
+        pkg_mirrors = resolver.query("_http._tcp.pkg.all.freebsd.org", "SRV")
 
     return pkg_mirrors
 


### PR DESCRIPTION
_http._tcp.pkg.FreeBSD.org only returns the GeoDNS and the primary/fallback mirror sites.  Use the special _http._tcp.pkg.all name instead, which also returns the local mirrors.