### PR TITLE
fastest_pkg.py: HTTPS

### DIFF
--- a/fastest_pkg/fastest_pkg.py
+++ b/fastest_pkg/fastest_pkg.py
@@ -146,7 +146,7 @@ def main():
         print(json.dumps(stats_sorted))
     else:
         pkg = PkgMirror(stats_sorted[0]["mirror_name"])
-        pkg_cfg = 'FreeBSD: { url: "http://%s/${ABI}/%s", mirror_type: "NONE" }' % (
+        pkg_cfg = 'FreeBSD: { url: "https://%s/${ABI}/%s", mirror_type: "NONE" }' % (
             stats_sorted[0]["mirror_name"],
             pkg.release,
         )


### PR DESCRIPTION
Towards consistency with [pkg: use https by default · freebsd/freebsd-src@d557a86](https://github.com/freebsd/freebsd-src/commit/d557a86c879a8515d59e8380b083b2265e9a3547)

`d557a86c879a pkg: use https by default`

From <https://reviews.freebsd.org/D40473>: 

> … base is providing a CA root bundle suitable to validate the certificates used by the project. …

Cross-reference: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=273833